### PR TITLE
chore: CLAUDE.mdにビルドコマンドとアーキテクチャ情報を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## 行動原則
 
 - **ユーザーの指示を最優先**: ユーザーが具体的な手順・順番を指示した場合、その通りに実行する。自己判断で順序を変えたり、勝手に追加作業をしない
@@ -7,11 +9,55 @@
 - **確認せず即実行**: 明確な指示に対して「〜しましょうか？」と聞き返さない。やれと言われたらやる
 - **余計なことをしない**: 頼まれていない作業（ファイルの調査、関連コードの読み込み等）を先回りでやらない。指示された範囲だけを実行する
 
+## Build & Test Commands
+
+```bash
+# テスト・チェック
+cargo test                    # 全テスト実行
+cargo test -p markdown        # 特定クレートのみ
+cargo fmt --check             # フォーマットチェック
+cargo check                   # コンパイルチェック
+
+# ビルド
+cargo run -p generator        # SSG実行 → dist/ に出力
+wasm-pack build wasm/ --target web --out-dir ../dist/scripts/pkg/  # WASMビルド
+```
+
 ## コーディング
 
 - `cargo fmt` を必ずコミット前に実行する
 - `cargo test` でテストが通ることを確認してからコミットする
 - 不要な未追跡ファイルはコミット前に削除する
+
+## Architecture
+
+Rust workspace による静的サイトジェネレータ + WASM クライアントフレームワーク。
+
+```
+posts/*.md → generator (SSR) → dist/*.html
+                                  ↓ ブラウザ
+                              wasm (client-side routing, reactivity)
+```
+
+### Workspace Members
+
+| Crate | Type | 役割 |
+|-------|------|------|
+| **markdown** | lib | Markdown→HTML 変換。lexer, tokenizer, generator で処理 |
+| **app** | proc-macro | `render!` マクロ（SSR/Client デュアルモード）と `#[component]` マクロ |
+| **generator** | bin | SSG。`posts/*.md` を読み、`dist/` にHTML・RSS生成 |
+| **wasm** | cdylib | Signal, Bindable, Router によるクライアントサイド SPA |
+
+### render! マクロのデュアルモード
+
+- **native target**: SSR パス — `String` を組み立てるコード生成（`codegen/ssr.rs`）
+- **wasm32 target**: Client パス — `web_sys` で DOM 要素を生成（`codegen/client.rs`）
+
+### Content
+
+- ブログ記事: `posts/{id}.md`（YAML frontmatter: id, title, description, created_at）
+- 生成先: `dist/index.html`, `dist/post/{id}/index.html`, `dist/rss.xml`
+- 静的ファイル: `styles/`, `scripts/` → `dist/` にコピー
 
 ## コミュニケーション
 


### PR DESCRIPTION
## 概要

CLAUDE.md にビルド・テストコマンドとアーキテクチャ情報を追加し、Claude Code が効率的に作業できるようにする。

## 変更点

- Build & Test Commands セクション追加（`cargo test`, `cargo run -p generator`, `wasm-pack build` 等）
- Architecture セクション追加（ワークスペース構成、各クレートの役割、render! デュアルモード、コンテンツ構造）
- ファイル冒頭に Claude Code 向けの説明文を追加