### PR TITLE
fix: 行頭インラインコードが段落から分離するバグを修正

### DIFF
--- a/markdown/src/generator.rs
+++ b/markdown/src/generator.rs
@@ -17,6 +17,10 @@ fn generate_inline_html(tokens: VecDeque<Token>) -> String {
                 output.push_str(&format!("<a href=\"{}\">{}</a>", url, text));
             }
             Token::InlineCode(content) => {
+                let content = content
+                    .replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;");
                 output.push_str(&format!("<code>{}</code>", content));
             }
             Token::Image { src, alt } => {
@@ -72,6 +76,10 @@ pub fn generate_html(tokens: VecDeque<Token>) -> String {
                 ));
             }
             Token::InlineCode(content) => {
+                let content = content
+                    .replace("&", "&amp;")
+                    .replace("<", "&lt;")
+                    .replace(">", "&gt;");
                 output.push_str(&format!("<code>{}</code>\n", content));
             }
             Token::BlockQuote(content) => {

--- a/markdown/src/generator.rs
+++ b/markdown/src/generator.rs
@@ -206,9 +206,11 @@ mod tests {
 
     #[test]
     fn test_generate_html_inline_code() {
-        let tokens = VecDeque::from(vec![Token::InlineCode("let x = 42;".to_string())]);
+        let tokens = VecDeque::from(vec![Token::Paragraph(vec![Token::InlineCode(
+            "let x = 42;".to_string(),
+        )])]);
         let html = generate_html(tokens);
-        assert_eq!(html, "<code>let x = 42;</code>\n");
+        assert_eq!(html, "<p><code>let x = 42;</code></p>\n");
     }
 
     #[test]

--- a/markdown/src/lexer.rs
+++ b/markdown/src/lexer.rs
@@ -59,7 +59,13 @@ impl<'a> Lexer<'a> {
                     Some(self.read_paragraph())
                 }
             }
-            Some('`') => Some(self.read_code_block_or_inline_code()),
+            Some('`') => {
+                if self.peek_char() == Some('`') {
+                    Some(self.read_code_block_or_inline_code())
+                } else {
+                    Some(self.read_paragraph())
+                }
+            }
             Some('>') => Some(self.read_quote()),
             Some('!') => {
                 if self.peek_char() == Some('[') {

--- a/markdown/src/tokenizer.rs
+++ b/markdown/src/tokenizer.rs
@@ -151,10 +151,11 @@ mod tests {
         let tokens = tokenize(input);
         assert_eq!(tokens.len(), 1);
         match tokens.get(0).unwrap() {
-            Token::InlineCode(content) => {
-                assert_eq!(content, "let x = 42;");
+            Token::Paragraph(content) => {
+                assert_eq!(content.len(), 1);
+                assert_eq!(content[0], Token::InlineCode("let x = 42;".to_string()));
             }
-            _ => panic!("Unexpected token"),
+            _ => panic!("Unexpected token: {:?}", tokens.get(0).unwrap()),
         }
     }
 


### PR DESCRIPTION
## 概要

行頭がバッククォートで始まる段落（例: `` `foo` bar baz ``）で、`<code>` が `<p>` の外に分離して生成されるバグを修正。

記事113などで段落の表示が崩れていた原因。

## 変更点

- `lexer.rs`: 行頭の単一バッククォートを `read_paragraph()` にディスパッチするよう変更（コードブロックの ``` のみ `read_code_block_or_inline_code()` に渡す）
- `tokenizer.rs`, `generator.rs`: テストを修正後の挙動に合わせて更新