### PR TITLE
chore: CLAUDE.md・README.md変更時のCI実行をスキップ

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
 jobs:
   Preview-Deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
 jobs:
   Preview-Deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
   pull_request:
     branches: ["main"]
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,14 @@ name: tests
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## 概要

ドキュメントのみの変更（CLAUDE.md・README.md）でCI不要なためスキップするよう設定。
`posts/**` はデプロイが必要なので引き続きCIが走る。

## 変更点

- 全ワークフロー（test / preview / deploy）に `paths-ignore` を追加
  - `CLAUDE.md`
  - `README.md`