### PR TITLE
feat: CSS-in-WASM スタイリングシステムを実装

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
 jobs:
   Preview-Deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
 jobs:
   Preview-Deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
   pull_request:
     branches: ["main"]
     paths-ignore:
       - "CLAUDE.md"
       - "README.md"
+      - ".claude/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,8 +3,14 @@ name: tests
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "CLAUDE.md"
+      - "README.md"
 
 env:
   CARGO_TERM_COLOR: always

--- a/app/src/css.rs
+++ b/app/src/css.rs
@@ -1,0 +1,66 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+fn fnv1a_hash(s: &str) -> u32 {
+    let mut hash: u32 = 2166136261;
+    for byte in s.bytes() {
+        hash ^= byte as u32;
+        hash = hash.wrapping_mul(16777619);
+    }
+    hash
+}
+
+pub fn css_impl(input: TokenStream) -> TokenStream {
+    let css_text = input.to_string();
+    let css_text = css_text.trim().to_string();
+
+    let hash = fnv1a_hash(&css_text);
+    let class_name = format!("css-{:06x}", hash & 0x00FF_FFFF);
+    let full_css = format!(".{} {{ {} }}", class_name, css_text);
+
+    quote! {{
+        const __NAME: &'static str = #class_name;
+        const __CSS: &'static str = #full_css;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        crate::style::push(__NAME, __CSS);
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            use ::wasm_bindgen::JsCast as _;
+            let __doc = ::web_sys::window().unwrap().document().unwrap();
+            if __doc.get_element_by_id(__NAME).is_none() {
+                let __el = __doc.create_element("style").unwrap();
+                __el.set_id(__NAME);
+                __el.set_inner_html(__CSS);
+                if let Some(__head) = __doc.head() {
+                    __head
+                        .append_child(__el.unchecked_ref::<::web_sys::Node>())
+                        .unwrap();
+                }
+            }
+        }
+
+        __NAME
+    }}
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fnv1a_hash;
+
+    #[test]
+    fn hash_is_stable() {
+        let h1 = fnv1a_hash("color: red;");
+        let h2 = fnv1a_hash("color: red;");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn different_css_different_hash() {
+        let h1 = fnv1a_hash("color: red;");
+        let h2 = fnv1a_hash("color: blue;");
+        assert_ne!(h1, h2);
+    }
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 
 mod codegen;
 mod component;
+mod css;
 mod tokenizer;
 
 use quote::quote;
@@ -20,6 +21,11 @@ pub fn render(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         { #client }
     }}
     .into()
+}
+
+#[proc_macro]
+pub fn css(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    css::css_impl(input)
 }
 
 #[proc_macro_attribute]

--- a/site/src/components/document.rs
+++ b/site/src/components/document.rs
@@ -10,6 +10,15 @@ pub struct DocumentProps {
 }
 
 pub fn document(props: DocumentProps) -> String {
+    let injected_style = {
+        let collected = crate::style::collect_and_clear();
+        if collected.is_empty() {
+            String::new()
+        } else {
+            format!("<style>{}</style>", collected)
+        }
+    };
+
     let hljs_css = if props.include_hljs {
         render! {
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/atom-one-dark.min.css"></link>
@@ -71,6 +80,7 @@ pub fn document(props: DocumentProps) -> String {
                     type="image/x-icon"
                 ></link>
                 <link rel="stylesheet" href="/styles/style.css"></link>
+                {injected_style}
                 {hljs_css}
                 <meta name="twitter:card" content="summary"></meta>
                 {og_title_meta}

--- a/site/src/lib.rs
+++ b/site/src/lib.rs
@@ -4,6 +4,8 @@ pub mod components;
 pub mod pages;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod routes;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod style;
 
 #[cfg(target_arch = "wasm32")]
 mod og;

--- a/site/src/style.rs
+++ b/site/src/style.rs
@@ -1,0 +1,27 @@
+use std::cell::RefCell;
+
+thread_local! {
+    static STYLES: RefCell<Vec<(&'static str, &'static str)>> = RefCell::new(Vec::new());
+}
+
+pub fn push(id: &'static str, css: &'static str) {
+    STYLES.with(|s| {
+        let mut styles = s.borrow_mut();
+        if !styles.iter().any(|(existing_id, _)| *existing_id == id) {
+            styles.push((id, css));
+        }
+    });
+}
+
+pub fn collect_and_clear() -> String {
+    STYLES.with(|s| {
+        let mut styles = s.borrow_mut();
+        let result = styles
+            .iter()
+            .map(|(_, css)| *css)
+            .collect::<Vec<_>>()
+            .join("\n");
+        styles.clear();
+        result
+    })
+}


### PR DESCRIPTION
## Summary

- `css!` proc-macro を追加。コンポーネントにスタイルを同居させる CSS-in-JS 相当の仕組みを WASM/Rust で実現
- SSR パス: thread-local レジストリ経由で `<head>` に `<style>` を注入
- WASM パス: `document.head` へ lazy inject（ID ガードで重複防止）
- opt-out 設計: `css!` を使わず既存の `class="name"` のままにすれば従来動作と変わらない

## 変更ファイル

| ファイル | 内容 |
|----------|------|
| `app/src/css.rs` | FNV-1a ハッシュで `css-{hash}` クラス名生成、SSR/WASM 両パスのコード生成 |
| `app/src/lib.rs` | `#[proc_macro] fn css` 登録 |
| `site/src/style.rs` | SSR thread-local レジストリ（`push` / `collect_and_clear`） |
| `site/src/lib.rs` | `#[cfg(not(wasm32))] pub mod style` 追加 |
| `site/src/components/document.rs` | `collect_and_clear()` 呼び出しと `<style>` を `style.css` 直後に注入 |

## 使用例

```rust
use app::{render, css};

let cls = css! { color: #333; font-size: 1rem; };
render! { <header class={cls}>...</header> }
```

## Test plan

- [x] `cargo test -p app` — ハッシュ安定性テスト通過
- [x] `cargo check` — 全クレートコンパイル確認
- [ ] `cargo run -p generator` → `dist/index.html` の `<head>` に `<style>` タグ確認
- [ ] ブラウザで `<head>` に `<style id="css-xxx">` が inject されていることを確認
- [ ] ページ遷移後も style タグが重複しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)