### PR TITLE
Codex rules で git と gh を常時許可

### DIFF
--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -15,6 +15,18 @@
 # - Bash(xargs -I {} bash -c 'echo "=== {} ===" && head -20 {}')
 
 prefix_rule(
+    pattern = ["git"],
+    decision = "allow",
+    justification = "Migrated from .claude permission: git",
+)
+
+prefix_rule(
+    pattern = ["gh"],
+    decision = "allow",
+    justification = "Migrated from .claude permission: gh",
+)
+
+prefix_rule(
     pattern = ["gh", "api"],
     decision = "allow",
     justification = "Migrated from .claude permission: gh api",
@@ -60,12 +72,6 @@ prefix_rule(
     pattern = ["cargo", "check"],
     decision = "prompt",
     justification = "Migrated from .claude permission: cargo check",
-)
-
-prefix_rule(
-    pattern = ["git"],
-    decision = "allow",
-    justification = "Migrated from .claude permission: git",
 )
 
 prefix_rule(

--- a/scripts/sync-claude-to-codex.py
+++ b/scripts/sync-claude-to-codex.py
@@ -204,6 +204,10 @@ def generate_rules(settings_local: dict) -> str:
     rules: list[list[str]] = []
     skipped: list[str] = []
 
+    for pattern in (["git"], ["gh"]):
+        seen.add(tuple(pattern))
+        rules.append(pattern)
+
     for entry in allow_entries:
         if not isinstance(entry, str):
             skipped.append(str(entry))


### PR DESCRIPTION
## 概要

Codex rules で git と gh コマンドを常時許可します。

## 変更点

- 同期スクリプトで git / gh の prefix rule を既定で生成
- .codex/rules/default.rules に git / gh の allow rule を追加

## 確認

- python3 scripts/sync-claude-to-codex.py --dry-run --delete
- git diff --check